### PR TITLE
Update Makefile phony targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,3 +13,5 @@ install:
 
 edit:
 	$(EDITOR) "$(MACRO_DIR)"/*
+
+.PHONY: source install edit

--- a/logs/codex_log_202507122223.md
+++ b/logs/codex_log_202507122223.md
@@ -1,0 +1,30 @@
+# Codex作業ログ（202507122223）
+## タスク概要（作業目的）
+Makefileターゲットを PHONY として明示
+
+## 実行したシェル／Gitコマンド
+- apply_patch: Makefile に .PHONY 追加
+- sed: タブインデント補正
+- make -n source
+- make -n install
+- make -n edit
+- git add Makefile logs/codex_log_202507122223.md
+- git commit -m 'chore: mark Makefile targets as phony'
+
+## 各コマンドの目的
+- Makefileの更新
+- インデントを維持するため
+- コマンドの実行内容確認
+- インストール手順確認
+- EDITモード確認
+- 変更のステージング
+- コミット作成
+
+## 実行結果（成功／失敗・テスト結果・バージョン変更など）
+- パッチ適用とインデント修正完了
+- makeコマンドは期待通りの出力を確認
+- コミット作成済み、バージョン変更なし
+
+## 影響ファイル
+- Makefile
+- logs/codex_log_202507122223.md


### PR DESCRIPTION
## Summary
- mark the Makefile targets `source`, `install`, `edit` as phony

## Testing
- `make -n source`
- `make -n install`
- `make -n edit`


------
https://chatgpt.com/codex/tasks/task_e_687261639fb88327bc61872a0136d19c